### PR TITLE
Add support for DartNativeExternalTypedData to enable zero-copy buffers

### DIFF
--- a/src/catch_unwind.rs
+++ b/src/catch_unwind.rs
@@ -13,7 +13,9 @@ use std::{
 pub struct CatchUnwind<F: Future>(#[pin] F);
 
 impl<F: Future> CatchUnwind<F> {
-    pub fn new(f: F) -> Self { Self(f) }
+    pub fn new(f: F) -> Self {
+        Self(f)
+    }
 }
 
 impl<F> Future for CatchUnwind<F>

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -126,6 +126,7 @@ pub struct DartNativeExternalTypedData {
 #[derive(Debug, Clone)]
 pub struct ZeroCopyBuffer<T>(pub T);
 
+#[doc(hidden)]
 #[no_mangle]
 pub unsafe extern "C" fn deallocate_rust_buffer(len: isize, ptr: *mut u8) {
     let len = len as usize;
@@ -166,7 +167,7 @@ impl Drop for DartCObject {
                             v.length as usize,
                         )
                     };
-                },
+                }
                 DartTypedDataType::Uint8 => {
                     let _ = unsafe {
                         Vec::from_raw_parts(
@@ -175,8 +176,8 @@ impl Drop for DartCObject {
                             v.length as usize,
                         )
                     };
-                },
-                _ => {},
+                }
+                _ => {}
             };
         }
     }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -79,6 +79,7 @@ pub union DartCObjectValue {
     pub as_capability: DartNativeCapability,
     pub as_array: DartNativeArray,
     pub as_typed_data: DartNativeTypedData,
+    pub as_external_typed_data: DartNativeExternalTypedData,
     _bindgen_union_align: [u64; 5usize],
 }
 
@@ -108,6 +109,16 @@ pub struct DartNativeTypedData {
     pub ty: DartTypedDataType,
     pub length: isize,
     pub values: *mut u8,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct DartNativeExternalTypedData {
+    pub ty: DartTypedDataType,
+    pub length: isize,
+    pub data: *mut u8,
+    pub peer: *mut u8,
+    pub callback: unsafe extern "C" fn(isize, *mut u8),
 }
 
 ///  Posts a message on some port. The message will contain the

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -121,6 +121,11 @@ pub struct DartNativeExternalTypedData {
     pub callback: unsafe extern "C" fn(isize, *mut u8),
 }
 
+/// Wrapping a Vec<u8> in this tuple struct will allow into_dart()
+/// to send it as a DartNativeExternalTypedData buffer with no copy overhead
+#[derive(Debug, Clone)]
+pub struct ZeroCopyBuffer<T>(pub T);
+
 #[no_mangle]
 pub unsafe extern "C" fn deallocate_rust_buffer(len: isize, ptr: *mut u8) {
     let len = len as usize;

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -121,6 +121,12 @@ pub struct DartNativeExternalTypedData {
     pub callback: unsafe extern "C" fn(isize, *mut u8),
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn deallocate_rust_buffer(len: isize, ptr: *mut u8) {
+    let len = len as usize;
+    drop(Vec::from_raw_parts(ptr, len, len));
+}
+
 ///  Posts a message on some port. The message will contain the
 ///  Dart_CObject object graph rooted in 'message'.
 ///

--- a/src/into_dart.rs
+++ b/src/into_dart.rs
@@ -191,12 +191,12 @@ impl IntoDart for Vec<i8> {
 }
 
 impl IntoDart for ZeroCopyBuffer<Vec<u8>> {
-    fn into_dart(mut self) -> DartCObject {
-        self.0.shrink_to_fit();
-        let length = self.0.len();
-        assert!(length == self.0.capacity());
-        let ptr = self.0.as_mut_ptr();
-        std::mem::forget(self);
+    fn into_dart(self) -> DartCObject {
+        let mut vec = ManuallyDrop::new(self.0);
+        vec.shrink_to_fit();
+        let length = vec.len();
+        assert!(length == vec.capacity());
+        let ptr = vec.as_mut_ptr();
 
         DartCObject {
             ty: DartCObjectType::DartExternalTypedData,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,9 @@ impl Isolate {
     /// # use allo_isolate::Isolate;
     /// let isolate = Isolate::new(42);
     /// ```
-    pub const fn new(port: i64) -> Self { Self { port } }
+    pub const fn new(port: i64) -> Self {
+        Self { port }
+    }
 
     /// Post an object to the [`Isolate`] over the port
     /// Object must implement [`IntoDart`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ mod into_dart;
 mod catch_unwind;
 
 pub mod ffi;
+pub use ffi::ZeroCopyBuffer;
 pub use into_dart::IntoDart;
 
 // Please don't use `AtomicPtr` here

--- a/test/containers.rs
+++ b/test/containers.rs
@@ -1,4 +1,4 @@
-use allo_isolate::Isolate;
+use allo_isolate::{ffi::ZeroCopyBuffer, Isolate};
 mod vm;
 
 fn main() {
@@ -33,4 +33,5 @@ fn main() {
     assert!(isolate.post(vec![String::from("Dart"); 1024]));
     assert!(isolate.post(vec![42u8; 100]));
     assert!(isolate.post(vec![42u128; 100]));
+    assert!(isolate.post(ZeroCopyBuffer(vec![42u8; 100])));
 }

--- a/test/vm.rs
+++ b/test/vm.rs
@@ -143,6 +143,18 @@ impl VMIsolate {
                     _ => unimplemented!(),
                 };
             },
+            DartExternalTypedData => {
+                let v = unsafe { o.value.as_external_typed_data };
+                let ty = v.ty;
+                match ty {
+                    DartTypedDataType::Uint8 => {
+                        let _ = unsafe {
+                            from_buf_raw(v.data as *mut u8, v.length as usize)
+                        };
+                    }
+                    _ => unimplemented!(),
+                };
+            }
             _ => {
                 unimplemented!();
             },

--- a/test/vm.rs
+++ b/test/vm.rs
@@ -149,7 +149,10 @@ impl VMIsolate {
                 match ty {
                     DartTypedDataType::Uint8 => {
                         let _ = unsafe {
-                            from_buf_raw(v.data as *mut u8, v.length as usize)
+                            let output = from_buf_raw(v.data as *mut u8, v.length as usize);
+                            let cb = v.callback;
+                            cb(v.length, v.peer);
+                            output
                         };
                     }
                     _ => unimplemented!(),

--- a/test/vm.rs
+++ b/test/vm.rs
@@ -49,7 +49,9 @@ impl DartVM {
 struct VMIsolate;
 
 impl VMIsolate {
-    const fn new() -> Self { Self }
+    const fn new() -> Self {
+        Self
+    }
 
     fn exec(&mut self, object: *mut DartCObject) -> bool {
         use DartCObjectType::*;
@@ -61,7 +63,7 @@ impl VMIsolate {
                     ty: DartNull,
                     value: DartCObjectValue { as_bool: false },
                 };
-            },
+            }
             DartBool => {
                 DartCObject {
                     ty: DartBool,
@@ -69,7 +71,7 @@ impl VMIsolate {
                         as_bool: unsafe { o.value.as_bool },
                     },
                 };
-            },
+            }
             DartInt32 => {
                 DartCObject {
                     ty: DartInt32,
@@ -77,7 +79,7 @@ impl VMIsolate {
                         as_int32: unsafe { o.value.as_int32 },
                     },
                 };
-            },
+            }
             DartInt64 => {
                 DartCObject {
                     ty: DartInt64,
@@ -85,7 +87,7 @@ impl VMIsolate {
                         as_int64: unsafe { o.value.as_int64 },
                     },
                 };
-            },
+            }
             DartDouble => {
                 DartCObject {
                     ty: DartDouble,
@@ -93,7 +95,7 @@ impl VMIsolate {
                         as_double: unsafe { o.value.as_double },
                     },
                 };
-            },
+            }
             DartString => {
                 {
                     let s =
@@ -105,7 +107,7 @@ impl VMIsolate {
                         },
                     }
                 };
-            },
+            }
             DartArray => {
                 // do something with o
                 // I'm semulating that I copied some data into the VM here
@@ -125,7 +127,7 @@ impl VMIsolate {
                         },
                     },
                 };
-            },
+            }
             DartTypedData => {
                 let v = unsafe { o.value.as_typed_data };
                 let ty = v.ty;
@@ -134,22 +136,25 @@ impl VMIsolate {
                         let _ = unsafe {
                             from_buf_raw(v.values as *mut i8, v.length as usize)
                         };
-                    },
+                    }
                     DartTypedDataType::Uint8 => {
                         let _ = unsafe {
                             from_buf_raw(v.values as *mut u8, v.length as usize)
                         };
-                    },
+                    }
                     _ => unimplemented!(),
                 };
-            },
+            }
             DartExternalTypedData => {
                 let v = unsafe { o.value.as_external_typed_data };
                 let ty = v.ty;
                 match ty {
                     DartTypedDataType::Uint8 => {
                         let _ = unsafe {
-                            let output = from_buf_raw(v.data as *mut u8, v.length as usize);
+                            let output = from_buf_raw(
+                                v.data as *mut u8,
+                                v.length as usize,
+                            );
                             let cb = v.callback;
                             cb(v.length, v.peer);
                             output
@@ -160,7 +165,7 @@ impl VMIsolate {
             }
             _ => {
                 unimplemented!();
-            },
+            }
         };
         true
     }
@@ -177,4 +182,6 @@ pub extern "C" fn dart_post_cobject(port: i64, msg: *mut DartCObject) -> bool {
     DART_VM.with(|vm| vm.post(port, msg))
 }
 
-pub fn port() -> i64 { DART_VM.with(|vm| vm.port()) }
+pub fn port() -> i64 {
+    DART_VM.with(|vm| vm.port())
+}


### PR DESCRIPTION
**Edit:** this has now been updated to add a `ZeroCopyBuffer` type. Usage is now simply:
```rust
use allo_isolate::ZeroCopyBuffer;

let buffer: Vec<u8> = serialization_lib::serialize(&data);
isolate.post(ZeroCopyBuffer(buffer));
```
<hr>
Since there is already an impl for `Vec<u8>` I'm not sure of a good way to add this zero-copy approach to `into_dart` without it conflicting with the existing copy approach so I've just included a working example below. For now we're doing the work shown in application code and passing the resulting `DartCObject` to `isolate.post()` and it works well. This PR adds the necessary types to enable that.

The Dart VM exposes both the `DartNativeTypedData` and the `DartNativeExternalTypedData` as a `Uint8List` but in the `DartNativeExternalTypedData` case the finalizer calls the provided `callback` to deallocate.

The implementation that sends a zero copy mutable buffer to Dart looks like this:
``` rust
impl IntoDart for Vec<u8> {
    fn into_dart(mut self) -> DartCObject {
        self.shrink_to_fit();
        let length = self.len();
        assert!(length == self.capacity());
        let ptr = self.as_mut_ptr();
        std::mem::forget(self);

        DartCObject {
            ty: DartCObjectType::DartExternalTypedData,
            value: DartCObjectValue {
                as_external_typed_data: DartNativeExternalTypedData {
                    ty: DartTypedDataType::Uint8,
                    length: length as isize,
                    data: ptr,
                    peer: ptr,
                    callback: deallocate_rust_buffer,
                },
            },
        }
    }
}
```