### PR TITLE
Fix bug that `u32`'s IntoDart will make the value completely wrong

### DIFF
--- a/src/into_dart_extra.rs
+++ b/src/into_dart_extra.rs
@@ -5,7 +5,7 @@
 use crate::{ffi::*, IntoDart};
 
 impl IntoDart for u32 {
-    fn into_dart(self) -> DartCObject { (self as i32).into_dart() }
+    fn into_dart(self) -> DartCObject { (self as i64).into_dart() }
 }
 
 impl IntoDart for u64 {

--- a/test/containers.rs
+++ b/test/containers.rs
@@ -1,4 +1,4 @@
-use allo_isolate::{Isolate, ZeroCopyBuffer};
+use allo_isolate::{ffi::DartCObjectType, IntoDart, Isolate, ZeroCopyBuffer};
 
 mod vm;
 
@@ -52,4 +52,13 @@ fn main() {
     assert!(isolate.post(ZeroCopyBuffer(vec![42u64; 100])));
     assert!(isolate.post(ZeroCopyBuffer(vec![42.0f32; 100])));
     assert!(isolate.post(ZeroCopyBuffer(vec![42.0f64; 100])));
+
+    {
+        // https://github.com/sunshine-protocol/allo-isolate/pull/17
+        let u32_into_dart = 0xfe112233_u32.into_dart();
+        assert_eq!(DartCObjectType::DartInt64, u32_into_dart.ty);
+        unsafe {
+            assert_eq!(0xfe112233_i64, u32_into_dart.value.as_int64);
+        }
+    }
 }


### PR DESCRIPTION
Please refer to https://github.com/fzyzcjy/flutter_rust_bridge/issues/234 for details.