### PR TITLE
backtrace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ license-file = "LICENSE"
 pin-project = { version = "1.0.8", optional = true }
 atomic = "0.5"
 anyhow = { version = "1.0.58", optional = true }
+backtrace = { version = "0.3.66", optional = true }
 
 [dev-dependencies]
 fastrand = "^1.3"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -9,5 +9,4 @@ reorder_impl_items = true
 use_field_init_shorthand = true
 use_try_shorthand = true
 normalize_doc_attributes = true
-report_fixme = "Always"
 edition = "2018"

--- a/src/into_dart.rs
+++ b/src/into_dart.rs
@@ -53,7 +53,6 @@ impl IntoDart for backtrace::Backtrace {
     fn into_dart(self) -> DartCObject { format!("{:?}", self).into_dart() }
 }
 
-
 impl IntoDart for i32 {
     fn into_dart(self) -> DartCObject {
         DartCObject {

--- a/src/into_dart.rs
+++ b/src/into_dart.rs
@@ -48,6 +48,12 @@ impl IntoDart for anyhow::Error {
     fn into_dart(self) -> DartCObject { format!("{:?}", self).into_dart() }
 }
 
+#[cfg(feature = "backtrace")]
+impl IntoDart for backtrace::Backtrace {
+    fn into_dart(self) -> DartCObject { format!("{:?}", self).into_dart() }
+}
+
+
 impl IntoDart for i32 {
     fn into_dart(self) -> DartCObject {
         DartCObject {


### PR DESCRIPTION
Adds optional support for Backtrace (which I think it's fair to have, just as anyhow), needed in https://github.com/fzyzcjy/flutter_rust_bridge/pull/582#discussion_r936184045

