### PR TITLE
Makes nested Vecs `IntoDart`

### DIFF
--- a/src/into_dart.rs
+++ b/src/into_dart.rs
@@ -26,9 +26,7 @@ impl<T> IntoDart for T
 where
     T: Into<DartCObject>,
 {
-    fn into_dart(self) -> DartCObject {
-        self.into()
-    }
+    fn into_dart(self) -> DartCObject { self.into() }
 }
 
 impl<T> IntoDartExceptPrimitive for T where T: IntoDart + Into<DartCObject> {}
@@ -47,16 +45,12 @@ impl IntoDart for () {
 
 #[cfg(feature = "anyhow")]
 impl IntoDart for anyhow::Error {
-    fn into_dart(self) -> DartCObject {
-        format!("{:?}", self).into_dart()
-    }
+    fn into_dart(self) -> DartCObject { format!("{:?}", self).into_dart() }
 }
 
 #[cfg(feature = "backtrace")]
 impl IntoDart for backtrace::Backtrace {
-    fn into_dart(self) -> DartCObject {
-        format!("{:?}", self).into_dart()
-    }
+    fn into_dart(self) -> DartCObject { format!("{:?}", self).into_dart() }
 }
 
 impl IntoDart for i32 {
@@ -78,9 +72,7 @@ impl IntoDart for i64 {
 }
 
 impl IntoDart for f32 {
-    fn into_dart(self) -> DartCObject {
-        (self as f64).into_dart()
-    }
+    fn into_dart(self) -> DartCObject { (self as f64).into_dart() }
 }
 
 impl IntoDart for f64 {
@@ -111,9 +103,7 @@ impl IntoDart for String {
 impl IntoDartExceptPrimitive for String {}
 
 impl IntoDart for &'_ str {
-    fn into_dart(self) -> DartCObject {
-        self.to_string().into_dart()
-    }
+    fn into_dart(self) -> DartCObject { self.to_string().into_dart() }
 }
 
 impl IntoDartExceptPrimitive for &'_ str {}

--- a/src/into_dart.rs
+++ b/src/into_dart.rs
@@ -26,7 +26,9 @@ impl<T> IntoDart for T
 where
     T: Into<DartCObject>,
 {
-    fn into_dart(self) -> DartCObject { self.into() }
+    fn into_dart(self) -> DartCObject {
+        self.into()
+    }
 }
 
 impl<T> IntoDartExceptPrimitive for T where T: IntoDart + Into<DartCObject> {}
@@ -45,12 +47,16 @@ impl IntoDart for () {
 
 #[cfg(feature = "anyhow")]
 impl IntoDart for anyhow::Error {
-    fn into_dart(self) -> DartCObject { format!("{:?}", self).into_dart() }
+    fn into_dart(self) -> DartCObject {
+        format!("{:?}", self).into_dart()
+    }
 }
 
 #[cfg(feature = "backtrace")]
 impl IntoDart for backtrace::Backtrace {
-    fn into_dart(self) -> DartCObject { format!("{:?}", self).into_dart() }
+    fn into_dart(self) -> DartCObject {
+        format!("{:?}", self).into_dart()
+    }
 }
 
 impl IntoDart for i32 {
@@ -72,7 +78,9 @@ impl IntoDart for i64 {
 }
 
 impl IntoDart for f32 {
-    fn into_dart(self) -> DartCObject { (self as f64).into_dart() }
+    fn into_dart(self) -> DartCObject {
+        (self as f64).into_dart()
+    }
 }
 
 impl IntoDart for f64 {
@@ -103,7 +111,9 @@ impl IntoDart for String {
 impl IntoDartExceptPrimitive for String {}
 
 impl IntoDart for &'_ str {
-    fn into_dart(self) -> DartCObject { self.to_string().into_dart() }
+    fn into_dart(self) -> DartCObject {
+        self.to_string().into_dart()
+    }
 }
 
 impl IntoDartExceptPrimitive for &'_ str {}
@@ -247,6 +257,8 @@ where
         DartArray::from(self.into_iter()).into_dart()
     }
 }
+
+impl<T> IntoDartExceptPrimitive for Vec<T> where T: IntoDartExceptPrimitive {}
 
 impl<T, const N: usize> IntoDart for ZeroCopyBuffer<[T; N]>
 where

--- a/tests/containers.rs
+++ b/tests/containers.rs
@@ -188,14 +188,10 @@ fn return_anyhow_error() -> anyhow::Result<()> {
     Err(anyhow::anyhow!("sample error"))
 }
 
-fn return_backtrace() -> backtrace::Backtrace {
-    backtrace::Backtrace::new()
-}
+fn return_backtrace() -> backtrace::Backtrace { backtrace::Backtrace::new() }
 
 #[cfg(test)]
 mod tests {
     #[test]
-    fn can_run_valgrind_main() {
-        super::main();
-    }
+    fn can_run_valgrind_main() { super::main(); }
 }

--- a/tests/containers.rs
+++ b/tests/containers.rs
@@ -114,6 +114,20 @@ fn main() {
 
     assert!(isolate.post(vec![String::from("Rust"); 8]));
     assert!(isolate.post(vec![String::from("Dart"); 1024]));
+    assert!(isolate.post(vec![
+        vec![String::from("Rust"); 8],
+        vec![String::from("Dart"); 1024]
+    ]));
+    assert!(isolate.post(vec![
+        vec![
+            vec![String::from("Rust"); 8],
+            vec![String::from("Dart"); 1024]
+        ],
+        vec![
+            vec![String::from("Rust"); 8],
+            vec![String::from("Dart"); 1024]
+        ]
+    ]));
     assert!(isolate.post(vec![42i8; 100]));
     assert!(isolate.post(vec![42u8; 100]));
     assert!(isolate.post(vec![42i16; 100]));
@@ -174,10 +188,14 @@ fn return_anyhow_error() -> anyhow::Result<()> {
     Err(anyhow::anyhow!("sample error"))
 }
 
-fn return_backtrace() -> backtrace::Backtrace { backtrace::Backtrace::new() }
+fn return_backtrace() -> backtrace::Backtrace {
+    backtrace::Backtrace::new()
+}
 
 #[cfg(test)]
 mod tests {
     #[test]
-    fn can_run_valgrind_main() { super::main(); }
+    fn can_run_valgrind_main() {
+        super::main();
+    }
 }


### PR DESCRIPTION
This fixes https://github.com/fzyzcjy/flutter_rust_bridge/issues/692

The only real change is to add
```rust
impl<T> IntoDartExceptPrimitive for Vec<T> where T: IntoDartExceptPrimitive {}
```

This makes all nested `Vec` `IntoDart`