### PR TITLE
Feat/chrono

### DIFF
--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: "--example containers --features 'anyhow backtrace'"
+          args: "--example containers --features 'anyhow backtrace chrono'"
 
       - name: Run valgrind
         run: valgrind --error-exitcode=1 --leak-check=full ./target/debug/examples/containers

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ atomic = "0.5"
 pin-project = { version = "1.0.8", optional = true }
 anyhow = { version = "1.0.58", optional = true }
 backtrace = { version = "0.3.66", optional = true }
+chrono = { version = "0.4.22", optional = true }
 
 [dev-dependencies]
 fastrand = "^1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ fastrand = "^1.3"
 [[example]]
 name = "containers"
 path = "tests/containers.rs"
-required-features = ["anyhow", "backtrace"]
+required-features = ["anyhow", "backtrace", "chrono"]
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ atomic = "0.5"
 pin-project = { version = "1.0.8", optional = true }
 anyhow = { version = "1.0.58", optional = true }
 backtrace = { version = "0.3.66", optional = true }
-chrono = { version = "0.4.22", optional = true }
+chrono = { version = "0.4.20", optional = true }
 
 [dev-dependencies]
 fastrand = "^1.3"

--- a/src/chrono.rs
+++ b/src/chrono.rs
@@ -11,7 +11,6 @@ impl IntoDart for chrono::DateTime<chrono::Utc> {
     ///   ```dart,ignore
     ///   DateTime.fromMicrosecondsSinceEpoch(raw, isUtc: true);
     ///   ```
-    ///   > beware that conversion is lossy, see more details in [Dart SDK issue](https://github.com/dart-lang/sdk/issues/44876).
     ///
     /// - hydrate into Rust [DateTime](chrono::DateTime)::<[Utc](chrono::Utc)>
     ///   ```rust,ignore
@@ -19,7 +18,7 @@ impl IntoDart for chrono::DateTime<chrono::Utc> {
     ///   let ns = (raw.rem_euclid(1_000_000) * 1_000) as u32;
     ///   chrono::DateTime::<chrono::Utc>::from_utc(chrono::NaiveDateTime::from_timestamp(s, ns), chrono::Utc);
     ///   ```
-    /// 
+    ///
     ///   note that it could overflow under the same conditions as of [chrono::NaiveDateTime::from_timestamp](https://docs.rs/chrono/latest/chrono/naive/struct.NaiveDateTime.html#method.from_timestamp)
     fn into_dart(self) -> DartCObject { self.timestamp_micros().into_dart() }
 }
@@ -31,7 +30,6 @@ impl IntoDart for chrono::DateTime<chrono::Local> {
     ///   ```dart,ignore
     ///   DateTime.fromMicrosecondsSinceEpoch(raw, isUtc: false);
     ///   ```
-    ///   > beware that conversion is lossy, see more details in [Dart SDK issue](https://github.com/dart-lang/sdk/issues/44876).
     ///
     /// - hydrate into Rust [DateTime](chrono::DateTime)::<[Local](chrono::Local)>
     ///   ```rust,ignore
@@ -39,7 +37,7 @@ impl IntoDart for chrono::DateTime<chrono::Local> {
     ///   let ns = (raw.rem_euclid(1_000_000) * 1_000) as u32;
     ///   chrono::DateTime::<chrono::Local>::from_local(chrono::NaiveDateTime::from_timestamp(s, ns), chrono::Local);
     ///   ```
-    /// 
+    ///
     ///   note that it could overflow under the same conditions as of [chrono::NaiveDateTime::from_timestamp](https://docs.rs/chrono/latest/chrono/naive/struct.NaiveDateTime.html#method.from_timestamp)
     fn into_dart(self) -> DartCObject { self.timestamp_micros().into_dart() }
 }

--- a/src/chrono.rs
+++ b/src/chrono.rs
@@ -11,6 +11,7 @@ impl IntoDart for chrono::DateTime<chrono::Utc> {
     ///   ```dart,ignore
     ///   DateTime.fromMicrosecondsSinceEpoch(raw, isUtc: true);
     ///   ```
+    ///   > beware that conversion is lossy, see more details in [Dart SDK issue](https://github.com/dart-lang/sdk/issues/44876).
     ///
     /// - hydrate into Rust [DateTime](chrono::DateTime)::<[Utc](chrono::Utc)>
     ///   ```rust,ignore
@@ -30,6 +31,7 @@ impl IntoDart for chrono::DateTime<chrono::Local> {
     ///   ```dart,ignore
     ///   DateTime.fromMicrosecondsSinceEpoch(raw, isUtc: false);
     ///   ```
+    ///   > beware that conversion is lossy, see more details in [Dart SDK issue](https://github.com/dart-lang/sdk/issues/44876).
     ///
     /// - hydrate into Rust [DateTime](chrono::DateTime)::<[Local](chrono::Local)>
     ///   ```rust,ignore

--- a/src/chrono.rs
+++ b/src/chrono.rs
@@ -51,6 +51,6 @@ impl IntoDart for chrono::Duration {
     ///   `Duration(microseconds: raw);`
     ///
     /// - hydrate into Rust [Duration](chrono::Duration)
-    /// `chrono::Duration::from_microseconds(raw);`
+    /// `chrono::Duration::microseconds(raw);`
     fn into_dart(self) -> DartCObject { self.num_microseconds().into_dart() }
 }

--- a/src/chrono.rs
+++ b/src/chrono.rs
@@ -35,6 +35,7 @@ impl IntoDart for chrono::DateTime<chrono::Local> {
 }
 
 impl IntoDart for chrono::NaiveDateTime {
+    /// on the other side of FFI, value should be reconstructed like [DateTime](chrono::DateTime)::<[Local](chrono::Local)>
     fn into_dart(self) -> DartCObject { self.timestamp_micros().into_dart() }
 }
 

--- a/src/chrono.rs
+++ b/src/chrono.rs
@@ -7,7 +7,7 @@ use crate::{ffi::DartCObject, IntoDart};
 impl IntoDart for chrono::DateTime<chrono::Utc> {
     /// on the other side of FFI, value should be reconstructed like:
     ///
-    /// - hydrate into Dart [DateTime](https://api.flutter.dev/flutter/dart-core/DateTime/DateTime.fromMicrosecondsSinceEpoch.html)
+    /// - hydrate into Dart [DateTime](https://api.dart.dev/stable/2.18.0/dart-core/DateTime/DateTime.fromMicrosecondsSinceEpoch.html)
     ///   ```dart,ignore
     ///   DateTime.fromMicrosecondsSinceEpoch(raw, isUtc: true);
     ///   ```
@@ -19,14 +19,14 @@ impl IntoDart for chrono::DateTime<chrono::Utc> {
     ///   chrono::DateTime::<chrono::Utc>::from_utc(chrono::NaiveDateTime::from_timestamp(s, ns), chrono::Utc);
     ///   ```
     ///
-    ///   note that it could overflow under the same conditions as of [chrono::NaiveDateTime::from_timestamp](https://docs.rs/chrono/latest/chrono/naive/struct.NaiveDateTime.html#method.from_timestamp)
+    ///   note that it could overflow under the same conditions as of [chrono::NaiveDateTime::from_timestamp](https://docs.rs/chrono/0.4.22/chrono/naive/struct.NaiveDateTime.html#method.from_timestamp)
     fn into_dart(self) -> DartCObject { self.timestamp_micros().into_dart() }
 }
 
 impl IntoDart for chrono::DateTime<chrono::Local> {
     /// on the other side of FFI, value should be reconstructed like:
     ///
-    /// - hydrate into Dart [DateTime](https://api.flutter.dev/flutter/dart-core/DateTime/DateTime.fromMicrosecondsSinceEpoch.html)
+    /// - hydrate into Dart [DateTime](https://api.dart.dev/stable/2.18.0/dart-core/DateTime/DateTime.fromMicrosecondsSinceEpoch.html)
     ///   ```dart,ignore
     ///   DateTime.fromMicrosecondsSinceEpoch(raw, isUtc: false);
     ///   ```
@@ -38,19 +38,20 @@ impl IntoDart for chrono::DateTime<chrono::Local> {
     ///   chrono::DateTime::<chrono::Local>::from_local(chrono::NaiveDateTime::from_timestamp(s, ns), chrono::Local);
     ///   ```
     ///
-    ///   note that it could overflow under the same conditions as of [chrono::NaiveDateTime::from_timestamp](https://docs.rs/chrono/latest/chrono/naive/struct.NaiveDateTime.html#method.from_timestamp)
+    ///   note that it could overflow under the same conditions as of [chrono::NaiveDateTime::from_timestamp](https://docs.rs/chrono/0.4.22/chrono/naive/struct.NaiveDateTime.html#method.from_timestamp)
     fn into_dart(self) -> DartCObject { self.timestamp_micros().into_dart() }
 }
 
 impl IntoDart for chrono::NaiveDateTime {
-    /// on the other side of FFI, value should be reconstructed like [DateTime](chrono::DateTime)::<[Local](chrono::Local)>
+    /// on the other side of FFI, value should be reconstructed like
+    /// [DateTime](chrono::DateTime)::<[Local](chrono::Local)>
     fn into_dart(self) -> DartCObject { self.timestamp_micros().into_dart() }
 }
 
 impl IntoDart for chrono::Duration {
     /// on the other side of FFI, value should be reconstructed like:
     ///
-    /// - hydrate into Dart [Duration](https://api.flutter.dev/flutter/dart-core/Duration/Duration.html)
+    /// - hydrate into Dart [Duration](https://api.dart.dev/stable/2.18.0/dart-core/Duration/Duration.html)
     ///   ```dart,ignore
     ///   Duration(microseconds: raw);
     ///   ```

--- a/src/chrono.rs
+++ b/src/chrono.rs
@@ -10,3 +10,7 @@ where
 impl IntoDart for chrono::NaiveDateTime {
     fn into_dart(self) -> DartCObject { self.timestamp_micros().into_dart() }
 }
+
+impl IntoDart for chrono::Duration {
+    fn into_dart(self) -> DartCObject { self.num_microseconds().into_dart() }
+}

--- a/src/chrono.rs
+++ b/src/chrono.rs
@@ -1,0 +1,7 @@
+use crate::{ffi::DartCObject, IntoDart};
+
+impl IntoDart for chrono::DateTime<chrono::Utc> {
+    fn into_dart(self) -> DartCObject {
+        self.timestamp_micros().into_dart()
+    }
+}

--- a/src/chrono.rs
+++ b/src/chrono.rs
@@ -4,10 +4,33 @@
 
 use crate::{ffi::DartCObject, IntoDart};
 
-impl<T> IntoDart for chrono::DateTime<T>
-where
-    T: chrono::TimeZone,
-{
+impl IntoDart for chrono::DateTime<chrono::Utc> {
+    /// on the other side of FFI, value should be reconstructed like:
+    ///
+    /// - hydrate into Dart [DateTime](https://api.flutter.dev/flutter/dart-core/DateTime/DateTime.fromMicrosecondsSinceEpoch.html)
+    ///   ```dart,ignore
+    ///   DateTime.fromMicrosecondsSinceEpoch(raw, isUtc: true);
+    ///   ```
+    ///
+    /// - hydrate into Rust [DateTime](chrono::DateTime)::<[Utc](chrono::Utc)>
+    ///   ```rust,ignore
+    ///   chrono::DateTime::<chrono::Utc>::from_utc(chrono::NaiveDateTime::from_timestamp(0, raw * 1_000), chrono::Utc);
+    ///   ```
+    fn into_dart(self) -> DartCObject { self.timestamp_micros().into_dart() }
+}
+
+impl IntoDart for chrono::DateTime<chrono::Local> {
+    /// on the other side of FFI, value should be reconstructed like:
+    ///
+    /// - hydrate into Dart [DateTime](https://api.flutter.dev/flutter/dart-core/DateTime/DateTime.fromMicrosecondsSinceEpoch.html)
+    ///   ```dart,ignore
+    ///   DateTime.fromMicrosecondsSinceEpoch(raw, isUtc: false);
+    ///   ```
+    ///
+    /// - hydrate into Rust [DateTime](chrono::DateTime)::<[Local](chrono::Local)>
+    ///   ```rust,ignore
+    ///   chrono::DateTime::<chrono::Local>::from_local(chrono::NaiveDateTime::from_timestamp(0, raw * 1_000), chrono::Local);
+    ///   ```
     fn into_dart(self) -> DartCObject { self.timestamp_micros().into_dart() }
 }
 
@@ -16,5 +39,16 @@ impl IntoDart for chrono::NaiveDateTime {
 }
 
 impl IntoDart for chrono::Duration {
+    /// on the other side of FFI, value should be reconstructed like:
+    ///
+    /// - hydrate into Dart [Duration](https://api.flutter.dev/flutter/dart-core/Duration/Duration.html)
+    ///   ```dart,ignore
+    ///   Duration(microseconds: raw);
+    ///   ```
+    ///
+    /// - hydrate into Rust [Duration](chrono::Duration)
+    ///   ```rust,ignore
+    ///   chrono::Duration::from_microseconds(raw);
+    ///   ```
     fn into_dart(self) -> DartCObject { self.num_microseconds().into_dart() }
 }

--- a/src/chrono.rs
+++ b/src/chrono.rs
@@ -8,9 +8,7 @@ impl IntoDart for chrono::DateTime<chrono::Utc> {
     /// on the other side of FFI, value should be reconstructed like:
     ///
     /// - hydrate into Dart [DateTime](https://api.dart.dev/stable/2.18.0/dart-core/DateTime/DateTime.fromMicrosecondsSinceEpoch.html)
-    ///   ```dart,ignore
-    ///   DateTime.fromMicrosecondsSinceEpoch(raw, isUtc: true);
-    ///   ```
+    ///   `DateTime.fromMicrosecondsSinceEpoch(raw, isUtc: true);`
     ///
     /// - hydrate into Rust [DateTime](chrono::DateTime)::<[Utc](chrono::Utc)>
     ///   ```rust,ignore
@@ -27,9 +25,7 @@ impl IntoDart for chrono::DateTime<chrono::Local> {
     /// on the other side of FFI, value should be reconstructed like:
     ///
     /// - hydrate into Dart [DateTime](https://api.dart.dev/stable/2.18.0/dart-core/DateTime/DateTime.fromMicrosecondsSinceEpoch.html)
-    ///   ```dart,ignore
-    ///   DateTime.fromMicrosecondsSinceEpoch(raw, isUtc: false);
-    ///   ```
+    ///   `DateTime.fromMicrosecondsSinceEpoch(raw, isUtc: false);`
     ///
     /// - hydrate into Rust [DateTime](chrono::DateTime)::<[Local](chrono::Local)>
     ///   ```rust,ignore
@@ -52,13 +48,9 @@ impl IntoDart for chrono::Duration {
     /// on the other side of FFI, value should be reconstructed like:
     ///
     /// - hydrate into Dart [Duration](https://api.dart.dev/stable/2.18.0/dart-core/Duration/Duration.html)
-    ///   ```dart,ignore
-    ///   Duration(microseconds: raw);
-    ///   ```
+    ///   `Duration(microseconds: raw);`
     ///
     /// - hydrate into Rust [Duration](chrono::Duration)
-    ///   ```rust,ignore
-    ///   chrono::Duration::from_microseconds(raw);
-    ///   ```
+    /// `chrono::Duration::from_microseconds(raw);`
     fn into_dart(self) -> DartCObject { self.num_microseconds().into_dart() }
 }

--- a/src/chrono.rs
+++ b/src/chrono.rs
@@ -14,8 +14,12 @@ impl IntoDart for chrono::DateTime<chrono::Utc> {
     ///
     /// - hydrate into Rust [DateTime](chrono::DateTime)::<[Utc](chrono::Utc)>
     ///   ```rust,ignore
-    ///   chrono::DateTime::<chrono::Utc>::from_utc(chrono::NaiveDateTime::from_timestamp(0, raw * 1_000), chrono::Utc);
+    ///   let s = (raw / 1_000_000) as i64;
+    ///   let ns = (raw % 1_000_000 * 1_000) as u32;
+    ///   chrono::DateTime::<chrono::Utc>::from_utc(chrono::NaiveDateTime::from_timestamp(s, ns), chrono::Utc);
     ///   ```
+    /// 
+    ///   note that it could overflow under the same conditions as of [chrono::NaiveDateTime::from_timestamp](https://docs.rs/chrono/latest/chrono/naive/struct.NaiveDateTime.html#method.from_timestamp)
     fn into_dart(self) -> DartCObject { self.timestamp_micros().into_dart() }
 }
 
@@ -29,8 +33,12 @@ impl IntoDart for chrono::DateTime<chrono::Local> {
     ///
     /// - hydrate into Rust [DateTime](chrono::DateTime)::<[Local](chrono::Local)>
     ///   ```rust,ignore
-    ///   chrono::DateTime::<chrono::Local>::from_local(chrono::NaiveDateTime::from_timestamp(0, raw * 1_000), chrono::Local);
+    ///   let s = (raw / 1_000_000) as i64;
+    ///   let ns = (raw % 1_000_000 * 1_000) as u32;
+    ///   chrono::DateTime::<chrono::Local>::from_local(chrono::NaiveDateTime::from_timestamp(s, ns), chrono::Local);
     ///   ```
+    /// 
+    ///   note that it could overflow under the same conditions as of [chrono::NaiveDateTime::from_timestamp](https://docs.rs/chrono/latest/chrono/naive/struct.NaiveDateTime.html#method.from_timestamp)
     fn into_dart(self) -> DartCObject { self.timestamp_micros().into_dart() }
 }
 

--- a/src/chrono.rs
+++ b/src/chrono.rs
@@ -1,5 +1,12 @@
 use crate::{ffi::DartCObject, IntoDart};
 
-impl IntoDart for chrono::DateTime<chrono::Utc> {
+impl<T> IntoDart for chrono::DateTime<T>
+where
+    T: chrono::TimeZone,
+{
+    fn into_dart(self) -> DartCObject { self.timestamp_micros().into_dart() }
+}
+
+impl IntoDart for chrono::NaiveDateTime {
     fn into_dart(self) -> DartCObject { self.timestamp_micros().into_dart() }
 }

--- a/src/chrono.rs
+++ b/src/chrono.rs
@@ -1,3 +1,7 @@
+//! chrono types
+//!
+//! based on Dart VM, microseconds unit is used
+
 use crate::{ffi::DartCObject, IntoDart};
 
 impl<T> IntoDart for chrono::DateTime<T>

--- a/src/chrono.rs
+++ b/src/chrono.rs
@@ -15,7 +15,7 @@ impl IntoDart for chrono::DateTime<chrono::Utc> {
     /// - hydrate into Rust [DateTime](chrono::DateTime)::<[Utc](chrono::Utc)>
     ///   ```rust,ignore
     ///   let s = (raw / 1_000_000) as i64;
-    ///   let ns = (raw % 1_000_000 * 1_000) as u32;
+    ///   let ns = (raw.rem_euclid(1_000_000) * 1_000) as u32;
     ///   chrono::DateTime::<chrono::Utc>::from_utc(chrono::NaiveDateTime::from_timestamp(s, ns), chrono::Utc);
     ///   ```
     /// 
@@ -34,7 +34,7 @@ impl IntoDart for chrono::DateTime<chrono::Local> {
     /// - hydrate into Rust [DateTime](chrono::DateTime)::<[Local](chrono::Local)>
     ///   ```rust,ignore
     ///   let s = (raw / 1_000_000) as i64;
-    ///   let ns = (raw % 1_000_000 * 1_000) as u32;
+    ///   let ns = (raw.rem_euclid(1_000_000) * 1_000) as u32;
     ///   chrono::DateTime::<chrono::Local>::from_local(chrono::NaiveDateTime::from_timestamp(s, ns), chrono::Local);
     ///   ```
     /// 

--- a/src/chrono.rs
+++ b/src/chrono.rs
@@ -1,7 +1,5 @@
 use crate::{ffi::DartCObject, IntoDart};
 
 impl IntoDart for chrono::DateTime<chrono::Utc> {
-    fn into_dart(self) -> DartCObject {
-        self.timestamp_micros().into_dart()
-    }
+    fn into_dart(self) -> DartCObject { self.timestamp_micros().into_dart() }
 }

--- a/src/into_dart.rs
+++ b/src/into_dart.rs
@@ -355,3 +355,10 @@ impl<T> IntoDart for *mut T {
         }
     }
 }
+
+#[cfg(feature = "chrono")]
+impl IntoDart for chrono::DateTime<chrono::Utc> {
+    fn into_dart(self) -> DartCObject {
+        self.timestamp_micros().into_dart()
+    }
+}

--- a/src/into_dart.rs
+++ b/src/into_dart.rs
@@ -355,10 +355,3 @@ impl<T> IntoDart for *mut T {
         }
     }
 }
-
-#[cfg(feature = "chrono")]
-impl IntoDart for chrono::DateTime<chrono::Utc> {
-    fn into_dart(self) -> DartCObject {
-        self.timestamp_micros().into_dart()
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,9 @@ mod into_dart_extra;
 #[cfg(feature = "catch-unwind")]
 mod catch_unwind;
 
+#[cfg(feature = "chrono")]
+mod chrono;
+
 pub mod ffi;
 
 // Please don't use `AtomicPtr` here

--- a/tests/containers.rs
+++ b/tests/containers.rs
@@ -184,10 +184,10 @@ fn main() {
     assert!(isolate.post(return_backtrace()));
     #[cfg(feature = "chrono")]
     {
-    	assert!(isolate.post(return_chrono_naive_date_time()));
-    	assert!(isolate.post(return_chrono_date_time_utc()));
-    	assert!(isolate.post(return_chrono_date_time_local()));
-    	assert!(isolate.post(return_chrono_duration()));
+        assert!(isolate.post(return_chrono_naive_date_time()));
+        assert!(isolate.post(return_chrono_date_time_utc()));
+        assert!(isolate.post(return_chrono_date_time_local()));
+        assert!(isolate.post(return_chrono_duration()));
     }
 
     println!("all done!");

--- a/tests/containers.rs
+++ b/tests/containers.rs
@@ -173,8 +173,6 @@ fn main() {
     #[cfg(feature = "chrono")]
     assert!(isolate.post(return_chrono_date_time_local()));
     #[cfg(feature = "chrono")]
-    assert!(isolate.post(return_chrono_date_time_east()));
-    #[cfg(feature = "chrono")]
     assert!(isolate.post(return_chrono_duration()));
 
     println!("all done!");
@@ -195,15 +193,6 @@ fn return_chrono_date_time_utc() -> chrono::DateTime<chrono::Utc> {
 #[cfg(feature = "chrono")]
 fn return_chrono_date_time_local() -> chrono::DateTime<chrono::Local> {
     chrono::Local::now()
-}
-#[cfg(feature = "chrono")]
-fn return_chrono_date_time_east() -> chrono::DateTime<chrono::FixedOffset> {
-    use chrono::TimeZone;
-    chrono::FixedOffset::east(7 * 3600)
-        .ymd(2016, 11, 08)
-        .and_hms(0, 0, 0)
-
-    // todo!()
 }
 #[cfg(feature = "chrono")]
 fn return_chrono_duration() -> chrono::Duration { chrono::Duration::hours(24) }

--- a/tests/containers.rs
+++ b/tests/containers.rs
@@ -183,6 +183,8 @@ fn main() {
     #[cfg(feature = "backtrace")]
     assert!(isolate.post(return_backtrace()));
     #[cfg(feature = "chrono")]
+    assert!(isolate.post(return_chrono_naive_date_time()));
+    #[cfg(feature = "chrono")]
     assert!(isolate.post(return_chrono_date_time_utc()));
     #[cfg(feature = "chrono")]
     assert!(isolate.post(return_chrono_date_time_local()));
@@ -200,6 +202,10 @@ fn return_anyhow_error() -> anyhow::Result<()> {
 #[cfg(feature = "backtrace")]
 fn return_backtrace() -> backtrace::Backtrace { backtrace::Backtrace::new() }
 
+#[cfg(feature = "chrono")]
+fn return_chrono_naive_date_time() -> chrono::NaiveDateTime {
+    chrono::NaiveDate::from_ymd(2016, 7, 8).and_hms_micro(9, 10, 11, 123_456)
+}
 #[cfg(feature = "chrono")]
 fn return_chrono_date_time_utc() -> chrono::DateTime<chrono::Utc> {
     chrono::Utc::now()

--- a/tests/containers.rs
+++ b/tests/containers.rs
@@ -164,16 +164,20 @@ fn main() {
         }
     }
 
+    #[cfg(feature = "anyhow")]
     assert!(isolate.post(return_anyhow_error()));
+    #[cfg(feature = "backtrace")]
     assert!(isolate.post(return_backtrace()));
 
     println!("all done!");
 }
 
+#[cfg(feature = "anyhow")]
 fn return_anyhow_error() -> anyhow::Result<()> {
     Err(anyhow::anyhow!("sample error"))
 }
 
+#[cfg(feature = "backtrace")]
 fn return_backtrace() -> backtrace::Backtrace { backtrace::Backtrace::new() }
 
 #[cfg(test)]

--- a/tests/containers.rs
+++ b/tests/containers.rs
@@ -183,9 +183,7 @@ fn return_anyhow_error() -> anyhow::Result<()> {
 fn return_backtrace() -> backtrace::Backtrace { backtrace::Backtrace::new() }
 
 #[cfg(feature = "chrono")]
-fn return_chrono() -> chrono::DateTime<chrono::Utc> {
-    chrono::Utc::now()
-}
+fn return_chrono() -> chrono::DateTime<chrono::Utc> { chrono::Utc::now() }
 
 #[cfg(test)]
 mod tests {

--- a/tests/containers.rs
+++ b/tests/containers.rs
@@ -169,7 +169,13 @@ fn main() {
     #[cfg(feature = "backtrace")]
     assert!(isolate.post(return_backtrace()));
     #[cfg(feature = "chrono")]
-    assert!(isolate.post(return_chrono()));
+    assert!(isolate.post(return_chrono_date_time_utc()));
+    #[cfg(feature = "chrono")]
+    assert!(isolate.post(return_chrono_date_time_local()));
+    #[cfg(feature = "chrono")]
+    assert!(isolate.post(return_chrono_date_time_east()));
+    #[cfg(feature = "chrono")]
+    assert!(isolate.post(return_chrono_duration()));
 
     println!("all done!");
 }
@@ -183,7 +189,24 @@ fn return_anyhow_error() -> anyhow::Result<()> {
 fn return_backtrace() -> backtrace::Backtrace { backtrace::Backtrace::new() }
 
 #[cfg(feature = "chrono")]
-fn return_chrono() -> chrono::DateTime<chrono::Utc> { chrono::Utc::now() }
+fn return_chrono_date_time_utc() -> chrono::DateTime<chrono::Utc> {
+    chrono::Utc::now()
+}
+#[cfg(feature = "chrono")]
+fn return_chrono_date_time_local() -> chrono::DateTime<chrono::Local> {
+    chrono::Local::now()
+}
+#[cfg(feature = "chrono")]
+fn return_chrono_date_time_east() -> chrono::DateTime<chrono::FixedOffset> {
+    use chrono::TimeZone;
+    chrono::FixedOffset::east(7 * 3600)
+        .ymd(2016, 11, 08)
+        .and_hms(0, 0, 0)
+
+    // todo!()
+}
+#[cfg(feature = "chrono")]
+fn return_chrono_duration() -> chrono::Duration { chrono::Duration::hours(24) }
 
 #[cfg(test)]
 mod tests {

--- a/tests/containers.rs
+++ b/tests/containers.rs
@@ -168,6 +168,8 @@ fn main() {
     assert!(isolate.post(return_anyhow_error()));
     #[cfg(feature = "backtrace")]
     assert!(isolate.post(return_backtrace()));
+    #[cfg(feature = "chrono")]
+    assert!(isolate.post(return_chrono()));
 
     println!("all done!");
 }
@@ -179,6 +181,11 @@ fn return_anyhow_error() -> anyhow::Result<()> {
 
 #[cfg(feature = "backtrace")]
 fn return_backtrace() -> backtrace::Backtrace { backtrace::Backtrace::new() }
+
+#[cfg(feature = "chrono")]
+fn return_chrono() -> chrono::DateTime<chrono::Utc> {
+    chrono::Utc::now()
+}
 
 #[cfg(test)]
 mod tests {

--- a/tests/containers.rs
+++ b/tests/containers.rs
@@ -183,13 +183,12 @@ fn main() {
     #[cfg(feature = "backtrace")]
     assert!(isolate.post(return_backtrace()));
     #[cfg(feature = "chrono")]
-    assert!(isolate.post(return_chrono_naive_date_time()));
-    #[cfg(feature = "chrono")]
-    assert!(isolate.post(return_chrono_date_time_utc()));
-    #[cfg(feature = "chrono")]
-    assert!(isolate.post(return_chrono_date_time_local()));
-    #[cfg(feature = "chrono")]
-    assert!(isolate.post(return_chrono_duration()));
+    {
+    	assert!(isolate.post(return_chrono_naive_date_time()));
+    	assert!(isolate.post(return_chrono_date_time_utc()));
+    	assert!(isolate.post(return_chrono_date_time_local()));
+    	assert!(isolate.post(return_chrono_duration()));
+    }
 
     println!("all done!");
 }


### PR DESCRIPTION
This PR offers to add [chrono](https://docs.rs/chrono/latest/chrono/) types conversion in a feature-gated way.
It would then allow supporting `chrono` types downstream in [flutter_rust_bridge](https://github.com/fzyzcjy/flutter_rust_bridge).

More details can be found in the [original discussion](https://github.com/fzyzcjy/flutter_rust_bridge/discussions/667), and in the subsequent [related external PR](https://github.com/fzyzcjy/flutter_rust_bridge/pull/694).

These first commits are incomplete, hence the _Draft_ status here : if approved, I'll then carry on with the missing changes.

As a short reminder, `DateTime<Utc>` and sibling types (`NaiveDateTime` and the likes) all boils down to `i64` under the hood. Notably though, Dart handles precision and representation differently in the VM (microseconds based) and in JavaScript (milliseconds based). As far as I understand, the nitty-gritty details would actually be the responsibility of downstream crate since for example `flutter_rust_bridge` will handle generating code wiring it through FFI to be able to reconstruct a `DateTime` on Dart side, a `DateTime<Utc>` on Rust side ~~, and whichever appropriate counterpart on JavaScript side (haven't looked into it yet but shouldn't be too much of a concern)~~.

**update:** my bad, there's no need to care about JS/WASM as rightfully pointed out.

