### PR TITLE
Feat/UUID

### DIFF
--- a/.github/workflows/performances.yml
+++ b/.github/workflows/performances.yml
@@ -1,0 +1,25 @@
+on: [push, pull_request]
+
+name: Stable benchmarks
+
+jobs:
+  performances:
+    name: Bench
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Run cargo bench
+        uses: actions-rs/cargo@v1
+        with:
+          command: bench
+          toolchain: stable
+          args: --bench uuid --features uuid

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: "--example containers --features 'anyhow backtrace chrono'"
+          args: "--example containers --features 'anyhow backtrace chrono uuid'"
 
       - name: Run valgrind
         run: valgrind --error-exitcode=1 --leak-check=full ./target/debug/examples/containers

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,12 @@ pin-project = { version = "1.0.8", optional = true }
 anyhow = { version = "1.0.58", optional = true }
 backtrace = { version = "0.3.66", optional = true }
 chrono = { version = "0.4.20", optional = true }
-uuid = { version = "1.1.2", optional = true, features = ["v4"] }
+uuid = { version = "1.1.2", optional = true }
 
 [dev-dependencies]
 fastrand = "^1.3"
 criterion = "0.3"
+uuid = { version = "1.1.2", features = ["v4"] }
 
 # These are used for tests
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "allo-isolate"
 version = "0.1.14-beta.2"
 authors = [
-    "Sunshine Foundation Developers",
-    "Shady Khalifa <dev@shadykhalifa.me>",
+  "Sunshine Foundation Developers",
+  "Shady Khalifa <dev@shadykhalifa.me>",
 ]
 edition = "2018"
 description = "Run Multithreaded Rust along with Dart VM (in isolate)."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,11 @@ pin-project = { version = "1.0.8", optional = true }
 anyhow = { version = "1.0.58", optional = true }
 backtrace = { version = "0.3.66", optional = true }
 chrono = { version = "0.4.20", optional = true }
-uuid = { version = "1.1.2", optional = true }
+uuid = { version = "1.1.2", optional = true, features = ["v4"] }
 
 [dev-dependencies]
 fastrand = "^1.3"
+criterion = "0.3"
 
 # These are used for tests
 [[example]]
@@ -37,3 +38,8 @@ catch-unwind = ["pin-project"]
 
 [package.metadata.docs.rs]
 all-features = true
+
+[[bench]]
+name = "uuid"
+harness = false
+required-features = ["uuid"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ fastrand = "^1.3"
 [[example]]
 name = "containers"
 path = "tests/containers.rs"
-required-features = ["anyhow", "backtrace", "chrono"]
+required-features = ["anyhow", "backtrace", "chrono", "uuid"]
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ pin-project = { version = "1.0.8", optional = true }
 anyhow = { version = "1.0.58", optional = true }
 backtrace = { version = "0.3.66", optional = true }
 chrono = { version = "0.4.20", optional = true }
+uuid = { version = "1.1.2", optional = true }
 
 [dev-dependencies]
 fastrand = "^1.3"

--- a/benches/uuid.rs
+++ b/benches/uuid.rs
@@ -1,0 +1,50 @@
+use std::io::Write;
+
+use allo_isolate::{ffi::DartCObject, IntoDart};
+use criterion::{
+    black_box, criterion_group, criterion_main, BenchmarkId, Criterion,
+};
+
+fn simple(uuids: Vec<uuid::Uuid>) -> DartCObject {
+    uuids
+        .into_iter()
+        .map(<uuid::Uuid as IntoDart>::into_dart)
+        .collect::<Vec<DartCObject>>()
+        .into_dart()
+}
+fn packed(uuids: Vec<uuid::Uuid>) -> DartCObject {
+    let mut buffer = Vec::<u8>::with_capacity(uuids.len() * 16);
+    for id in uuids {
+        let _ = buffer.write(id.as_bytes());
+    }
+    buffer.into_dart()
+}
+
+fn uuids(count: usize) -> Vec<uuid::Uuid> {
+    let mut buffer = Vec::with_capacity(count);
+    for _ in 0..count {
+        buffer.push(uuid::Uuid::new_v4());
+    }
+    buffer
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("uuid into dart");
+    for i in [100, 1000, 100_000, 1000_000].iter() {
+        let input = uuids(*i);
+        group.bench_with_input(
+            BenchmarkId::new("Delegate to inner type", i),
+            i,
+            |b, _| b.iter(|| simple(black_box(input.clone()))),
+        );
+        group.bench_with_input(
+            BenchmarkId::new("Pack all in one", i),
+            i,
+            |b, _| b.iter(|| packed(black_box(input.clone()))),
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,9 @@ mod catch_unwind;
 #[cfg(feature = "chrono")]
 mod chrono;
 
+#[cfg(feature = "uuid")]
+mod uuid;
+
 pub mod ffi;
 
 // Please don't use `AtomicPtr` here

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -1,10 +1,10 @@
 //! uuid type
 
-use crate::IntoDart;
+use crate::{ffi::DartCObject, IntoDart};
 
 impl IntoDart for uuid::Uuid {
     /// delegate to `Vec<u8>` implementation
-    fn into_dart(self) -> crate::ffi::DartCObject {
+    fn into_dart(self) -> DartCObject {
         self.as_bytes().to_vec().into_dart()
     }
 }

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -24,7 +24,7 @@ impl IntoDart for Vec<uuid::Uuid> {
     ///
     /// on the other side of FFI, value should be reconstructed like:
     ///
-    /// - hydrate into Dart [UuidValue](https://pub.dev/documentation/uuid/latest/uuid/UuidValue-class.html)
+    /// - hydrate into Dart List<[UuidValue](https://pub.dev/documentation/uuid/latest/uuid/UuidValue-class.html)>
     ///   ```dart
     ///   final count = raw.lengthInBytes / 16;
     ///   var List<UuidValue> ids = List(growable: true);
@@ -33,7 +33,7 @@ impl IntoDart for Vec<uuid::Uuid> {
     ///   }
     ///   ```
     ///
-    /// - hydrate into Rust [Uuid](uuid::Uuid)
+    /// - hydrate into Rust Vec<[Uuid](uuid::Uuid)>
     ///   ```rust,ignore
     ///   raw
     ///   .as_slice()

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -20,7 +20,7 @@ impl IntoDart for uuid::Uuid {
 }
 
 impl IntoDart for Vec<uuid::Uuid> {
-    /// delegate to `Vec<u8>` implementation but concatenates outputs in a single Vec<u8>
+    /// ⚠️ concatenated in a single `Vec<u8>` for performance optimization
     ///
     /// on the other side of FFI, value should be reconstructed like:
     ///

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -4,7 +4,7 @@ use crate::{ffi::DartCObject, IntoDart};
 
 impl IntoDart for uuid::Uuid {
     /// delegate to `Vec<u8>` implementation
-    /// 
+    ///
     /// on the other side of FFI, value should be reconstructed like:
     ///
     /// - hydrate into Dart [UuidValue](https://pub.dev/documentation/uuid/latest/uuid/UuidValue-class.html)

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -4,6 +4,16 @@ use crate::{ffi::DartCObject, IntoDart};
 
 impl IntoDart for uuid::Uuid {
     /// delegate to `Vec<u8>` implementation
+    /// 
+    /// on the other side of FFI, value should be reconstructed like:
+    ///
+    /// - hydrate into Dart [UuidValue](https://pub.dev/documentation/uuid/latest/uuid/UuidValue-class.html)
+    ///   `UuidValue.fromByteList(raw);`
+    ///
+    /// - hydrate into Rust [Uuid](uuid::Uuid)
+    ///   ```rust,ignore
+    ///   uuid::Uuid::from_bytes(*<&[u8] as std::convert::TryInto<&[u8;16]>>::try_into(raw.as_slice()).expect("invalid uuid slice"));
+    ///   ```
     fn into_dart(self) -> DartCObject {
         self.as_bytes().to_vec().into_dart()
     }

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -40,6 +40,8 @@ impl IntoDart for Vec<uuid::Uuid> {
     ///   .map(|x: &[u8]| uuid::Uuid::from_bytes(*<&[u8] as std::convert::TryInto<&[u8;16]>>::try_into(x).expect("invalid uuid slice")))
     ///   .collect();
     ///   ```
+    /// 
+    /// note that buffer could end up being incomplete under the same conditions as of [std::io::Write::write](https://doc.rust-lang.org/std/io/trait.Write.html#tymethod.write).
     fn into_dart(self) -> DartCObject {
         use std::io::Write;
         let mut buffer = Vec::<u8>::with_capacity(self.len() * 16);

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -21,6 +21,26 @@ impl IntoDart for uuid::Uuid {
 
 impl IntoDart for Vec<uuid::Uuid> {
     /// delegate to `Vec<u8>` implementation but concatenates outputs in a single Vec<u8>
+    ///
+    /// on the other side of FFI, value should be reconstructed like:
+    ///
+    /// - hydrate into Dart [UuidValue](https://pub.dev/documentation/uuid/latest/uuid/UuidValue-class.html)
+    ///   ```dart
+    ///   final count = raw.lengthInBytes / 16;
+    ///   var List<UuidValue> ids = List(growable: true);
+    ///   for (var i = 0; i < count; i += 16) {
+    ///     ids.add(UuidValue.fromByteList(Uint8List.view(raw.buffer, i * 16, 16)))
+    ///   }
+    ///   ```
+    ///
+    /// - hydrate into Rust [Uuid](uuid::Uuid)
+    ///   ```rust,ignore
+    ///   raw
+    ///   .as_slice()
+    ///   .chunks(16)
+    ///   .map(|x: &[u8]| uuid::Uuid::from_bytes(*<&[u8] as std::convert::TryInto<&[u8;16]>>::try_into(x).expect("invalid uuid slice")))
+    ///   .collect();
+    ///   ```
     fn into_dart(self) -> DartCObject {
         self.into_iter()
             .map(|x| x.as_bytes().to_vec())

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -3,8 +3,8 @@
 use crate::IntoDart;
 
 impl IntoDart for uuid::Uuid {
-    /// delegate to `[u8;16]` implementation
+    /// delegate to `Vec<u8>` implementation
     fn into_dart(self) -> crate::ffi::DartCObject {
-        (*self.as_bytes()).into_dart()
+        self.as_bytes().to_vec().into_dart()
     }
 }

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -18,3 +18,14 @@ impl IntoDart for uuid::Uuid {
         self.as_bytes().to_vec().into_dart()
     }
 }
+
+impl IntoDart for Vec<uuid::Uuid> {
+    /// delegate to `Vec<u8>` implementation but concatenates outputs in a single Vec<u8>
+    fn into_dart(self) -> DartCObject {
+        self.into_iter()
+            .map(|x| x.as_bytes().to_vec())
+            .flatten()
+            .collect::<Vec<u8>>()
+            .into_dart()
+    }
+}

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -26,11 +26,10 @@ impl IntoDart for Vec<uuid::Uuid> {
     ///
     /// - hydrate into Dart List<[UuidValue](https://pub.dev/documentation/uuid/latest/uuid/UuidValue-class.html)>
     ///   ```dart
-    ///   final count = raw.lengthInBytes / 16;
-    ///   var List<UuidValue> ids = List(growable: true);
-    ///   for (var i = 0; i < count; i += 16) {
-    ///     ids.add(UuidValue.fromByteList(Uint8List.view(raw.buffer, i * 16, 16)))
-    ///   }
+    ///   return List<UuidValue>.generate(
+    ///     raw.lengthInBytes / 16,
+    ///     (int i) => UuidValue.fromByteList(Uint8List.view(raw.buffer, i * 16, 16)),
+    ///     growable: false);
     ///   ```
     ///
     /// - hydrate into Rust Vec<[Uuid](uuid::Uuid)>

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -1,0 +1,10 @@
+//! uuid type
+
+use crate::IntoDart;
+
+impl IntoDart for uuid::Uuid {
+    /// delegate to `[u8;16]` implementation
+    fn into_dart(self) -> crate::ffi::DartCObject {
+        (*self.as_bytes()).into_dart()
+    }
+}

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -44,9 +44,7 @@ impl IntoDart for Vec<uuid::Uuid> {
         use std::io::Write;
         let mut buffer = Vec::<u8>::with_capacity(self.len() * 16);
         for id in self {
-            buffer
-                .write(id.as_bytes())
-                .expect("write uuids bytes to buffer");
+            let _ = buffer.write(id.as_bytes());
         }
         buffer.into_dart()
     }

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -42,10 +42,11 @@ impl IntoDart for Vec<uuid::Uuid> {
     ///   .collect();
     ///   ```
     fn into_dart(self) -> DartCObject {
-        self.into_iter()
-            .map(|x| x.as_bytes().to_vec())
-            .flatten()
-            .collect::<Vec<u8>>()
-            .into_dart()
+        use std::io::Write;
+        let mut buffer = Vec::<u8>::with_capacity(self.len() * 16);
+        for id in self {
+            let _ = buffer.write(id.as_bytes());
+        }
+        buffer.into_dart()
     }
 }

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -40,7 +40,7 @@ impl IntoDart for Vec<uuid::Uuid> {
     ///   .map(|x: &[u8]| uuid::Uuid::from_bytes(*<&[u8] as std::convert::TryInto<&[u8;16]>>::try_into(x).expect("invalid uuid slice")))
     ///   .collect();
     ///   ```
-    /// 
+    ///
     /// note that buffer could end up being incomplete under the same conditions as of [std::io::Write::write](https://doc.rust-lang.org/std/io/trait.Write.html#tymethod.write).
     fn into_dart(self) -> DartCObject {
         use std::io::Write;

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -44,7 +44,9 @@ impl IntoDart for Vec<uuid::Uuid> {
         use std::io::Write;
         let mut buffer = Vec::<u8>::with_capacity(self.len() * 16);
         for id in self {
-            let _ = buffer.write(id.as_bytes());
+            buffer
+                .write(id.as_bytes())
+                .expect("write uuids bytes to buffer");
         }
         buffer.into_dart()
     }

--- a/tests/containers.rs
+++ b/tests/containers.rs
@@ -189,6 +189,8 @@ fn main() {
         assert!(isolate.post(return_chrono_date_time_local()));
         assert!(isolate.post(return_chrono_duration()));
     }
+    #[cfg(feature = "uuid")]
+    assert!(isolate.post(return_uuid()));
 
     println!("all done!");
 }
@@ -218,6 +220,11 @@ fn return_chrono_date_time_local() -> chrono::DateTime<chrono::Local> {
 #[cfg(feature = "chrono")]
 fn return_chrono_duration() -> chrono::Duration {
     chrono::Duration::hours(24)
+}
+
+#[cfg(feature = "uuid")]
+fn return_uuid() -> uuid::Uuid {
+    uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap()
 }
 
 #[cfg(test)]

--- a/tests/containers.rs
+++ b/tests/containers.rs
@@ -190,7 +190,10 @@ fn main() {
         assert!(isolate.post(return_chrono_duration()));
     }
     #[cfg(feature = "uuid")]
-    assert!(isolate.post(return_uuid()));
+    {
+        assert!(isolate.post(return_uuid()));
+        assert!(isolate.post(return_uuids()))
+    }
 
     println!("all done!");
 }
@@ -225,6 +228,13 @@ fn return_chrono_duration() -> chrono::Duration {
 #[cfg(feature = "uuid")]
 fn return_uuid() -> uuid::Uuid {
     uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap()
+}
+#[cfg(feature = "uuid")]
+fn return_uuids() -> Vec<uuid::Uuid> {
+    vec![
+        uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap(),
+        uuid::Uuid::parse_str("a1a2a3a4-b1b2-c1c2-d1d2-d3d4d5d6d7d8").unwrap(),
+    ]
 }
 
 #[cfg(test)]


### PR DESCRIPTION
In the same fashion, this PR adds support for [uuid crate](https://docs.rs/uuid), since it's widely used in app and web alike.
I'm gonna keep as _Draft_ until it's implemented downstream on `flutter_rust_bridge` (please hold on for a while, previous PR for `chrono` types is almost finished but not quite yet).