### PR TITLE
Add basic support for vec of chrono types

### DIFF
--- a/src/chrono.rs
+++ b/src/chrono.rs
@@ -6,7 +6,11 @@
 //! as these are generally easier to work with.
 //! > see [timestamp_micros](https://docs.rs/chrono/0.4.20/chrono/naive/struct.NaiveDateTime.html?search=timestamp_micros#method.timestamp_micros)
 
-use crate::{ffi::DartCObject, IntoDart};
+use crate::{
+    ffi::{DartCObject, DartHandleFinalizer, DartTypedDataType},
+    into_dart::{free_zero_copy_buffer_i64, DartTypedDataTypeTrait},
+    IntoDart,
+};
 
 impl IntoDart for chrono::DateTime<chrono::Utc> {
     /// on the other side of FFI, value should be reconstructed like:
@@ -97,6 +101,16 @@ impl<const N: usize> IntoDart for [chrono::DateTime<chrono::Utc>; N] {
     }
 }
 
+impl DartTypedDataTypeTrait for chrono::DateTime<chrono::Utc> {
+    fn dart_typed_data_type() -> DartTypedDataType {
+        DartTypedDataType::Int64
+    }
+
+    fn function_pointer_of_free_zero_copy_buffer() -> DartHandleFinalizer {
+        free_zero_copy_buffer_i64
+    }
+}
+
 impl IntoDart for Vec<chrono::DateTime<chrono::Local>> {
     fn into_dart(self) -> DartCObject {
         self.iter()
@@ -113,6 +127,16 @@ impl<const N: usize> IntoDart for [chrono::DateTime<chrono::Local>; N] {
     }
 }
 
+impl DartTypedDataTypeTrait for chrono::DateTime<chrono::Local> {
+    fn dart_typed_data_type() -> DartTypedDataType {
+        DartTypedDataType::Int64
+    }
+
+    fn function_pointer_of_free_zero_copy_buffer() -> DartHandleFinalizer {
+        free_zero_copy_buffer_i64
+    }
+}
+
 impl IntoDart for Vec<chrono::NaiveDateTime> {
     fn into_dart(self) -> DartCObject {
         self.iter()
@@ -126,6 +150,16 @@ impl<const N: usize> IntoDart for [chrono::NaiveDateTime; N] {
     fn into_dart(self) -> DartCObject {
         let vec: Vec<_> = self.into();
         vec.into_dart()
+    }
+}
+
+impl DartTypedDataTypeTrait for chrono::NaiveDateTime {
+    fn dart_typed_data_type() -> DartTypedDataType {
+        DartTypedDataType::Int64
+    }
+
+    fn function_pointer_of_free_zero_copy_buffer() -> DartHandleFinalizer {
+        free_zero_copy_buffer_i64
     }
 }
 

--- a/src/chrono.rs
+++ b/src/chrono.rs
@@ -80,3 +80,67 @@ impl IntoDart for chrono::Duration {
         self.num_microseconds().into_dart()
     }
 }
+
+impl IntoDart for Vec<chrono::DateTime<chrono::Utc>> {
+    fn into_dart(self) -> DartCObject {
+        self.iter()
+            .map(chrono::DateTime::<chrono::Utc>::timestamp_micros)
+            .collect::<Vec<_>>()
+            .into_dart()
+    }
+}
+
+impl<const N: usize> IntoDart for [chrono::DateTime<chrono::Utc>; N] {
+    fn into_dart(self) -> DartCObject {
+        let vec: Vec<_> = self.into();
+        vec.into_dart()
+    }
+}
+
+impl IntoDart for Vec<chrono::DateTime<chrono::Local>> {
+    fn into_dart(self) -> DartCObject {
+        self.iter()
+            .map(chrono::DateTime::<chrono::Local>::timestamp_micros)
+            .collect::<Vec<_>>()
+            .into_dart()
+    }
+}
+
+impl<const N: usize> IntoDart for [chrono::DateTime<chrono::Local>; N] {
+    fn into_dart(self) -> DartCObject {
+        let vec: Vec<_> = self.into();
+        vec.into_dart()
+    }
+}
+
+impl IntoDart for Vec<chrono::NaiveDateTime> {
+    fn into_dart(self) -> DartCObject {
+        self.iter()
+            .map(chrono::NaiveDateTime::timestamp_micros)
+            .collect::<Vec<_>>()
+            .into_dart()
+    }
+}
+
+impl<const N: usize> IntoDart for [chrono::NaiveDateTime; N] {
+    fn into_dart(self) -> DartCObject {
+        let vec: Vec<_> = self.into();
+        vec.into_dart()
+    }
+}
+
+impl IntoDart for Vec<chrono::Duration> {
+    fn into_dart(self) -> DartCObject {
+        self.iter()
+            .map(chrono::Duration::num_microseconds)
+            .collect::<Vec<_>>()
+            .into_dart()
+    }
+}
+
+impl<const N: usize> IntoDart for [chrono::Duration; N] {
+    fn into_dart(self) -> DartCObject {
+        let vec: Vec<_> = self.into();
+        vec.into_dart()
+    }
+}

--- a/src/into_dart.rs
+++ b/src/into_dart.rs
@@ -184,7 +184,7 @@ macro_rules! dart_typed_data_type_trait_impl {
 
             #[doc(hidden)]
             #[no_mangle]
-            unsafe extern "C" fn $free_zero_copy_buffer_func(
+            pub(crate) unsafe extern "C" fn $free_zero_copy_buffer_func(
                 isolate_callback_data: *mut c_void,
                 peer: *mut c_void,
             ) {


### PR DESCRIPTION
Hello!
I didn't realized last time after implementing support for `chrono` that I omitted `Vec` and array.
So here they are, I took a naive approach because I wasn't sure if using `dart_typed_data_type_trait_impl` was the right thing to do (`chrono` types are slightly different since they boild down to their inner type, `i64`). I can change the implementation if needed.