### PR TITLE
Add extra support for array and zero copy of uuid type

### DIFF
--- a/src/into_dart.rs
+++ b/src/into_dart.rs
@@ -184,7 +184,7 @@ macro_rules! dart_typed_data_type_trait_impl {
 
             #[doc(hidden)]
             #[no_mangle]
-            unsafe extern "C" fn $free_zero_copy_buffer_func(
+            pub(crate) unsafe extern "C" fn $free_zero_copy_buffer_func(
                 isolate_callback_data: *mut c_void,
                 peer: *mut c_void,
             ) {

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -1,6 +1,10 @@
 //! uuid type
 
-use crate::{ffi::DartCObject, IntoDart};
+use crate::{
+    ffi::{DartCObject, DartHandleFinalizer, DartTypedDataType},
+    into_dart::{free_zero_copy_buffer_u8, DartTypedDataTypeTrait},
+    IntoDart,
+};
 
 impl IntoDart for uuid::Uuid {
     /// delegate to `Vec<u8>` implementation
@@ -49,5 +53,22 @@ impl IntoDart for Vec<uuid::Uuid> {
             let _ = buffer.write(id.as_bytes());
         }
         buffer.into_dart()
+    }
+}
+
+impl<const N: usize> IntoDart for [uuid::Uuid; N] {
+    fn into_dart(self) -> DartCObject {
+        let vec: Vec<_> = self.into();
+        vec.into_dart()
+    }
+}
+
+impl DartTypedDataTypeTrait for uuid::Uuid {
+    fn dart_typed_data_type() -> DartTypedDataType {
+        DartTypedDataType::Uint8
+    }
+
+    fn function_pointer_of_free_zero_copy_buffer() -> DartHandleFinalizer {
+        free_zero_copy_buffer_u8
     }
 }


### PR DESCRIPTION
Similar to previous PR, this one aims at providing missing support to `uuid` for array and `ZeroCopyBuffer`.
For `DartTypedDataTypeTrait` I'm wasn't sure so since it boils down to a `Vec<u8>`, I assumed it translates to `DartTypedDataType::Uint8` and `free_zero_copy_buffer_u8`.