### PR TITLE
Fixed a bug with `zero-copy` cargo feature

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -4,7 +4,7 @@ name: Nightly lints
 
 jobs:
   combo:
-    name: Clippy + rustfmt
+    name: Clippy + rustfmt (without features)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -25,15 +25,52 @@ jobs:
           toolchain: stable
           components: rustfmt
 
-      - name: Run cargo fmt
+      - name: Run tests without features
         uses: actions-rs/cargo@v1
         with:
           command: fmt
           toolchain: stable
           args: --all -- --check
 
-      - name: Run cargo clippy
+      - name: Run clippy without features
         uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: -- -D warnings
+  combo-with-feature:
+    name: Clippy + rustfmt (with features)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        features: ["catch-unwind", "zero-copy"]
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+          components: clippy
+
+      - name: Install stable toolchain (rustfmt)
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: rustfmt
+
+      - name: Run tests for feature ${{ matrix.features }}
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          toolchain: stable
+          args: --all -- --check --features ${{ matrix.features }}
+
+      - name: Run clippy for feature ${{ matrix.features }}
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings --features ${{ matrix.features }}

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -67,10 +67,12 @@ jobs:
         with:
           command: fmt
           toolchain: stable
-          args: --all -- --check --features ${{ matrix.features }}
+          args: --all -- --check
+          features: ${{ matrix.features }}
 
       - name: Run clippy for feature ${{ matrix.features }}
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings --features ${{ matrix.features }}
+          args: -- -D warnings
+          features: ${{ matrix.features }}

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -38,7 +38,7 @@ jobs:
           command: clippy
           args: -- -D warnings
   combo-with-feature:
-    name: Clippy + rustfmt (with features)
+    name: Clippy + rustfmt (with a feature)
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -32,7 +32,7 @@ jobs:
           toolchain: stable
           args: --all -- --check
 
-      - name: Run clippy without features
+      - name: Run cargo clippy without features
         uses: actions-rs/cargo@v1
         with:
           command: clippy
@@ -70,7 +70,7 @@ jobs:
           args: --all -- --check
           features: ${{ matrix.features }}
 
-      - name: Run clippy for feature ${{ matrix.features }}
+      - name: Run cargo clippy for feature ${{ matrix.features }}
         uses: actions-rs/cargo@v1
         with:
           command: clippy

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -25,7 +25,7 @@ jobs:
           toolchain: stable
           components: rustfmt
 
-      - name: Run tests without features
+      - name: Run cargo fmt without features
         uses: actions-rs/cargo@v1
         with:
           command: fmt
@@ -62,7 +62,7 @@ jobs:
           toolchain: stable
           components: rustfmt
 
-      - name: Run tests for feature ${{ matrix.features }}
+      - name: Run cargo fmt for feature ${{ matrix.features }}
         uses: actions-rs/cargo@v1
         with:
           command: fmt

--- a/src/into_dart.rs
+++ b/src/into_dart.rs
@@ -145,6 +145,32 @@ pub trait DartTypedDataTypeTrait {
     fn function_pointer_of_free_zero_copy_buffer() -> DartHandleFinalizer;
 }
 
+fn vec_to_dart_native_external_type_data<T>(
+    vec_from_rust: Vec<T>,
+) -> DartCObject
+where
+    T: DartTypedDataTypeTrait,
+{
+    let mut vec = ManuallyDrop::new(vec_from_rust);
+    vec.shrink_to_fit();
+    let length = vec.len();
+    assert_eq!(length, vec.capacity());
+    let ptr = vec.as_mut_ptr();
+
+    DartCObject {
+        ty: DartCObjectType::DartExternalTypedData,
+        value: DartCObjectValue {
+            as_external_typed_data: DartNativeExternalTypedData {
+                ty: T::dart_typed_data_type(),
+                length: length as isize,
+                data: ptr as *mut u8,
+                peer: ptr as *mut c_void,
+                callback: T::function_pointer_of_free_zero_copy_buffer(),
+            },
+        },
+    }
+}
+
 macro_rules! dart_typed_data_type_trait_impl {
     ($($dart_type:path => $rust_type:ident + $free_zero_copy_buffer_func:ident),+) => {
         $(
@@ -185,24 +211,7 @@ macro_rules! dart_typed_data_type_trait_impl {
             #[cfg(feature="zero-copy")]
             impl IntoDart for Vec<$rust_type> {
                 fn into_dart(self) -> DartCObject {
-                    let mut vec = ManuallyDrop::new(self);
-                    vec.shrink_to_fit();
-                    let length = vec.len();
-                    assert_eq!(length, vec.capacity());
-                    let ptr = vec.as_mut_ptr();
-
-                    DartCObject {
-                        ty: DartCObjectType::DartExternalTypedData,
-                        value: DartCObjectValue {
-                            as_external_typed_data: DartNativeExternalTypedData {
-                                ty: $rust_type::dart_typed_data_type(),
-                                length: length as isize,
-                                data: ptr as *mut u8,
-                                peer: ptr as *mut c_void,
-                                callback: $rust_type::function_pointer_of_free_zero_copy_buffer(),
-                            },
-                        },
-                    }
+                    vec_to_dart_native_external_type_data(self)
                 }
             }
 
@@ -247,24 +256,7 @@ where
     T: DartTypedDataTypeTrait,
 {
     fn into_dart(self) -> DartCObject {
-        let mut vec = ManuallyDrop::new(self.0);
-        vec.shrink_to_fit();
-        let length = vec.len();
-        assert_eq!(length, vec.capacity());
-        let ptr = vec.as_mut_ptr();
-
-        DartCObject {
-            ty: DartCObjectType::DartExternalTypedData,
-            value: DartCObjectValue {
-                as_external_typed_data: DartNativeExternalTypedData {
-                    ty: T::dart_typed_data_type(),
-                    length: length as isize,
-                    data: ptr as *mut u8,
-                    peer: ptr as *mut c_void,
-                    callback: T::function_pointer_of_free_zero_copy_buffer(),
-                },
-            },
-        }
+        vec_to_dart_native_external_type_data(self.0)
     }
 }
 

--- a/src/into_dart.rs
+++ b/src/into_dart.rs
@@ -185,7 +185,7 @@ macro_rules! dart_typed_data_type_trait_impl {
             #[cfg(feature="zero-copy")]
             impl IntoDart for Vec<$rust_type> {
                 fn into_dart(self) -> DartCObject {
-                    let mut vec = self;
+                    let mut vec = ManuallyDrop::new(self);
                     vec.shrink_to_fit();
                     let length = vec.len();
                     assert_eq!(length, vec.capacity());

--- a/src/into_dart.rs
+++ b/src/into_dart.rs
@@ -145,7 +145,7 @@ pub trait DartTypedDataTypeTrait {
     fn function_pointer_of_free_zero_copy_buffer() -> DartHandleFinalizer;
 }
 
-fn vec_to_dart_native_external_type_data<T>(
+fn vec_to_dart_native_external_typed_data<T>(
     vec_from_rust: Vec<T>,
 ) -> DartCObject
 where
@@ -211,7 +211,7 @@ macro_rules! dart_typed_data_type_trait_impl {
             #[cfg(feature="zero-copy")]
             impl IntoDart for Vec<$rust_type> {
                 fn into_dart(self) -> DartCObject {
-                    vec_to_dart_native_external_type_data(self)
+                    vec_to_dart_native_external_typed_data(self)
                 }
             }
 
@@ -256,7 +256,7 @@ where
     T: DartTypedDataTypeTrait,
 {
     fn into_dart(self) -> DartCObject {
-        vec_to_dart_native_external_type_data(self.0)
+        vec_to_dart_native_external_typed_data(self.0)
     }
 }
 

--- a/src/into_dart.rs
+++ b/src/into_dart.rs
@@ -185,7 +185,7 @@ macro_rules! dart_typed_data_type_trait_impl {
             #[cfg(feature="zero-copy")]
             impl IntoDart for Vec<$rust_type> {
                 fn into_dart(self) -> DartCObject {
-                    let mut vec = ManuallyDrop::new(self.0);
+                    let mut vec = self;
                     vec.shrink_to_fit();
                     let length = vec.len();
                     assert_eq!(length, vec.capacity());


### PR DESCRIPTION
I am sorry to tell that I left out one of the most important changes when I was making the previous #39 PR.

`self` should be passed to `ManuallyDrop` instead of `self.0`, because this one doesn't have a `ZeroCopyBuffer` wrapper. I apologize for the mistake.