### PR TITLE
Implement IntoDart for tuples

### DIFF
--- a/src/into_dart.rs
+++ b/src/into_dart.rs
@@ -383,3 +383,29 @@ impl<T> IntoDart for *mut T {
         }
     }
 }
+
+macro_rules! impl_into_dart_for_tuple {
+    ($( ($($A:ident)+) )*) => {$(
+        impl<$($A: IntoDart),+> IntoDart for ($($A),+,) {
+            #[allow(non_snake_case)]
+            fn into_dart(self) -> DartCObject {
+                let ($($A),+,) = self;
+                vec![$($A.into_dart()),+].into_dart()
+            }
+        }
+        impl<$($A: IntoDart),+> IntoDartExceptPrimitive for ($($A),+,) {}
+    )*};
+}
+
+impl_into_dart_for_tuple! {
+    (A)
+    (A B)
+    (A B C)
+    (A B C D)
+    (A B C D E)
+    (A B C D E F)
+    (A B C D E F G)
+    (A B C D E F G H)
+    (A B C D E F G H I)
+    (A B C D E F G H I J)
+}

--- a/tests/containers.rs
+++ b/tests/containers.rs
@@ -196,6 +196,11 @@ fn main() {
         assert!(isolate.post(return_uuids()))
     }
 
+    assert!(isolate.post(("asd", "asd".to_string(), 123)));
+    assert!(isolate.post(((true,), (123,))));
+    assert!(isolate.post((ZeroCopyBuffer(vec![-1]), vec![-1], 1.1)));
+    assert!(isolate.post((1, 2, 3, 4, 5, 6, 7, 8, 9, (10, 11))));
+
     println!("all done!");
 }
 

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -60,7 +60,7 @@ impl VMIsolate {
     fn exec(&mut self, object: *mut DartCObject) -> bool {
         use DartCObjectType::*;
         assert!(!object.is_null(), "got a null object");
-        let o = unsafe { &*object };
+        let o = unsafe { &mut *object };
         match o.ty {
             DartNull => {
                 DartCObject {
@@ -113,6 +113,12 @@ impl VMIsolate {
                 };
             },
             DartArray => {
+                // In a real application, the Dart VM would keep the array and its elements around
+                // and let GC eventually reclaim it. This prevents memory leaks e.g. resulting from external
+                // typed arrays nested inside of arrays and hence not being cleaned up.
+                unsafe {
+                    allo_isolate::ffi::run_destructors(o);
+                }
                 // do something with o
                 // I'm semulating that I copied some data into the VM here
                 let v: Vec<_> = vec![0u32; 0]


### PR DESCRIPTION
Dart 3 opened up the possibility of translating Rust tuples into Dart records. This PR enables downstream libraries like flutter_rust_bridge to work around orphan rules and have tuples also implement `IntoDart`.