### PR TITLE
Implement `IntoDartExceptPrimitive` for `bool`

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -224,7 +224,7 @@ impl Drop for DartCObject {
 
 /// Exposed only for tests.
 #[doc(hidden)]
-pub unsafe fn run_destructors(obj: &mut DartCObject) {
+pub unsafe fn run_destructors(obj: &DartCObject) {
     use DartCObjectType::*;
     match obj.ty {
         DartExternalTypedData => unsafe {
@@ -241,7 +241,7 @@ pub unsafe fn run_destructors(obj: &mut DartCObject) {
                 )
             };
             for item in items {
-                run_destructors(&mut **item)
+                run_destructors(&**item)
             }
         },
         _ => {},

--- a/src/into_dart.rs
+++ b/src/into_dart.rs
@@ -101,6 +101,10 @@ impl IntoDart for bool {
     }
 }
 
+// https://github.com/sunshine-protocol/allo-isolate/pull/47
+//
+// Since Dart doesn't have a primitive list implemented for boolean (e.g. `Uint8List` for 8-bit unsigned int),
+// we should implement `IntoDartExceptPrimitive` for `bool` so that `Vec<bool>` can be converted to `List<bool>`.
 impl IntoDartExceptPrimitive for bool {}
 
 impl IntoDart for String {

--- a/src/into_dart.rs
+++ b/src/into_dart.rs
@@ -101,6 +101,8 @@ impl IntoDart for bool {
     }
 }
 
+impl IntoDartExceptPrimitive for bool {}
+
 impl IntoDart for String {
     fn into_dart(self) -> DartCObject {
         let s = CString::new(self).unwrap_or_default();

--- a/tests/containers.rs
+++ b/tests/containers.rs
@@ -20,6 +20,8 @@ fn main() {
     assert!(!isolate.post(vec![42u64; 100]));
     assert!(!isolate.post(vec![42.0f32; 100]));
     assert!(!isolate.post(vec![42.0f64; 100]));
+    assert!(!isolate.post(vec![true; 100]));
+    assert!(!isolate.post(vec![false; 100]));
     assert!(!isolate.post(ZeroCopyBuffer(vec![42i8; 100])));
     assert!(!isolate.post(ZeroCopyBuffer(vec![42u8; 100])));
     assert!(!isolate.post(ZeroCopyBuffer(vec![42i16; 100])));
@@ -41,6 +43,8 @@ fn main() {
     assert!(!isolate.post([42u64; 100]));
     assert!(!isolate.post([42.0f32; 100]));
     assert!(!isolate.post([42.0f64; 100]));
+    assert!(!isolate.post([true; 100]));
+    assert!(!isolate.post([false; 100]));
     assert!(!isolate.post(ZeroCopyBuffer([42i8; 100])));
     assert!(!isolate.post(ZeroCopyBuffer([42u8; 100])));
     assert!(!isolate.post(ZeroCopyBuffer([42i16; 100])));
@@ -139,6 +143,8 @@ fn main() {
     assert!(isolate.post(vec![42u64; 100]));
     assert!(isolate.post(vec![42.0f32; 100]));
     assert!(isolate.post(vec![42.0f64; 100]));
+    assert!(isolate.post(vec![true; 100]));
+    assert!(isolate.post(vec![false; 100]));
     assert!(isolate.post(ZeroCopyBuffer(vec![42i8; 100])));
     assert!(isolate.post(ZeroCopyBuffer(vec![42u8; 100])));
     assert!(isolate.post(ZeroCopyBuffer(vec![42i16; 100])));
@@ -160,6 +166,8 @@ fn main() {
     assert!(isolate.post([42u64; 100]));
     assert!(isolate.post([42.0f32; 100]));
     assert!(isolate.post([42.0f64; 100]));
+    assert!(isolate.post([true; 100]));
+    assert!(isolate.post([false; 100]));
     assert!(isolate.post(ZeroCopyBuffer([42i8; 100])));
     assert!(isolate.post(ZeroCopyBuffer([42u8; 100])));
     assert!(isolate.post(ZeroCopyBuffer([42i16; 100])));


### PR DESCRIPTION
Refer to fzyzcjy/flutter_rust_bridge#801 and fzyzcjy/flutter_rust_bridge#1353.

`bool` should implement `IntoDartExceptPrimitive` so that `Vec<bool>` can be converted to `List<bool>`, since Dart does not have a primitive list implemented for boolean (e.g. `Uint8List` for 8-bit unsigned int).