### PR TITLE
Make `zero-copy` and `ZeroCopyBuffer` work with `Vec<T>` of length 0

### DIFF
--- a/src/into_dart.rs
+++ b/src/into_dart.rs
@@ -157,13 +157,7 @@ fn vec_to_dart_native_external_typed_data<T>(
 where
     T: DartTypedDataTypeTrait,
 {
-    let mut vec = ManuallyDrop::new(vec_from_rust);
-    vec.shrink_to_fit();
-    let length = vec.len();
-    assert_eq!(length, vec.capacity());
-    let ptr = vec.as_mut_ptr();
-
-    if length == 0 {
+    if vec_from_rust.len() == 0 {
         let data = DartNativeTypedData {
             ty: T::dart_typed_data_type(),
             length: 0,
@@ -176,6 +170,12 @@ where
             },
         };
     }
+    
+    let mut vec = ManuallyDrop::new(vec_from_rust);
+    vec.shrink_to_fit();
+    let length = vec.len();
+    assert_eq!(length, vec.capacity());
+    let ptr = vec.as_mut_ptr();
 
     DartCObject {
         ty: DartCObjectType::DartExternalTypedData,

--- a/src/into_dart.rs
+++ b/src/into_dart.rs
@@ -157,7 +157,7 @@ fn vec_to_dart_native_external_typed_data<T>(
 where
     T: DartTypedDataTypeTrait,
 {
-    if vec_from_rust.len() == 0 {
+    if vec_from_rust.is_empty() {
         let data = DartNativeTypedData {
             ty: T::dart_typed_data_type(),
             length: 0,
@@ -170,7 +170,7 @@ where
             },
         };
     }
-    
+
     let mut vec = ManuallyDrop::new(vec_from_rust);
     vec.shrink_to_fit();
     let length = vec.len();

--- a/src/into_dart.rs
+++ b/src/into_dart.rs
@@ -163,6 +163,20 @@ where
     assert_eq!(length, vec.capacity());
     let ptr = vec.as_mut_ptr();
 
+    if length == 0 {
+        let data = DartNativeTypedData {
+            ty: T::dart_typed_data_type(),
+            length: 0,
+            values: std::ptr::null_mut(),
+        };
+        return DartCObject {
+            ty: DartCObjectType::DartTypedData,
+            value: DartCObjectValue {
+                as_typed_data: data,
+            },
+        };
+    }
+
     DartCObject {
         ty: DartCObjectType::DartExternalTypedData,
         value: DartCObjectValue {

--- a/tests/containers.rs
+++ b/tests/containers.rs
@@ -22,6 +22,7 @@ fn main() {
     assert!(!isolate.post(vec![42.0f64; 100]));
     assert!(!isolate.post(vec![true; 100]));
     assert!(!isolate.post(vec![false; 100]));
+    assert!(!isolate.post(ZeroCopyBuffer(vec![0u8; 0])));
     assert!(!isolate.post(ZeroCopyBuffer(vec![42i8; 100])));
     assert!(!isolate.post(ZeroCopyBuffer(vec![42u8; 100])));
     assert!(!isolate.post(ZeroCopyBuffer(vec![42i16; 100])));
@@ -45,6 +46,7 @@ fn main() {
     assert!(!isolate.post([42.0f64; 100]));
     assert!(!isolate.post([true; 100]));
     assert!(!isolate.post([false; 100]));
+    assert!(!isolate.post(ZeroCopyBuffer([0u8; 0])));
     assert!(!isolate.post(ZeroCopyBuffer([42i8; 100])));
     assert!(!isolate.post(ZeroCopyBuffer([42u8; 100])));
     assert!(!isolate.post(ZeroCopyBuffer([42i16; 100])));


### PR DESCRIPTION
### Summary

When enabling the `zero-copy` feature or using `ZeroCopyBuffer`, `Vec<T>` with length of 0 always made the Dart-Rust app crash. This turned out to be a behavior with `isolate_callback_data`, which returns proper length value when the length of `Vec<T>` was not 0, but returns an oddly big number when `Vec<T>` has zero length.

https://github.com/cunarist/rust-in-flutter/issues/165

### Experiment

Adding some `println!()`s can help us inspect this problem.

```rust
// into_dart.rs

fn vec_to_dart_native_external_typed_data<T>(
    vec_from_rust: Vec<T>,
) -> DartCObject
where
    T: DartTypedDataTypeTrait,
{
    let mut vec = ManuallyDrop::new(vec_from_rust);
    vec.shrink_to_fit();
    let length = vec.len();
    assert_eq!(length, vec.capacity());
    let ptr = vec.as_mut_ptr();
    println!("{:?}, {:?}", ptr, length); // THIS LINE

    DartCObject {
        ty: DartCObjectType::DartExternalTypedData,
        value: DartCObjectValue {
            as_external_typed_data: DartNativeExternalTypedData {
                ty: T::dart_typed_data_type(),
                length: length as isize,
                data: ptr as *mut u8,
                peer: ptr as *mut c_void,
                callback: T::function_pointer_of_free_zero_copy_buffer(),
            },
        },
    }
}
```

```rust
// into_dart.rs

            #[doc(hidden)]
            #[no_mangle]
            pub(crate) unsafe extern "C" fn $free_zero_copy_buffer_func(
                isolate_callback_data: *mut c_void,
                peer: *mut c_void,
            ) {
                let len = (isolate_callback_data as isize) as usize;
                let ptr = peer as *mut $rust_type;
                println!("{:?}, {:?}", ptr, len); // THIS LINE
                drop(Vec::from_raw_parts(ptr, len, len));
            }
        )+
```

When passing in `Vec<T>` of 6 bytes with `zero-copy` feature enabled(or using `ZeroCopyBuffer`), we get this output:

```
0x1, 6
0x1, 6
```

When passing in `Vec<T>` of 0 bytes with `zero-copy` feature enabled(or using `ZeroCopyBuffer`), we get this output:

```
0x1, 0
0x1, 140208384468704
```

The length value from Rust `Vec<T>` is correct, but the length value from `isolate_callback_data` is very weird. This led to deallocating memory of a totally wrong location which always made the Dart-Rust app crash.

I've confirmed that this change effectively works on an actual project that uses `Vec<T>` of length 0 with `zero-copy`. Tests are also added in this PR.