### PR TITLE
Fix `[[A; N]; M]` cannot be used with allo isolate

### DIFF
--- a/src/into_dart.rs
+++ b/src/into_dart.rs
@@ -403,6 +403,8 @@ where
     }
 }
 
+impl<T, const N: usize> IntoDartExceptPrimitive for [T; N] where T: IntoDartExceptPrimitive {}
+
 impl<T> IntoDart for Option<T>
 where
     T: IntoDart,

--- a/src/into_dart.rs
+++ b/src/into_dart.rs
@@ -403,7 +403,10 @@ where
     }
 }
 
-impl<T, const N: usize> IntoDartExceptPrimitive for [T; N] where T: IntoDartExceptPrimitive {}
+impl<T, const N: usize> IntoDartExceptPrimitive for [T; N] where
+    T: IntoDartExceptPrimitive
+{
+}
 
 impl<T> IntoDart for Option<T>
 where


### PR DESCRIPTION
Fix https://github.com/fzyzcjy/flutter_rust_bridge/issues/2703
