### PR TITLE
chore: specify license in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["bindings", "ffi", "isolate", "dart"]
 categories = ["external-ffi-bindings", "development-tools::ffi"]
 readme = "README.md"
 homepage = "https://github.com/sunshine-protocol/allo-isolate"
+license = "Apache-2.0"
 license-file = "LICENSE"
 
 [dependencies]


### PR DESCRIPTION
In particular, it makes `cargo deny` happy.